### PR TITLE
Update dts Makefile to include overlays directory

### DIFF
--- a/arch/arm64/boot/dts/Makefile
+++ b/arch/arm64/boot/dts/Makefile
@@ -24,3 +24,5 @@ subdir-y += socionext
 subdir-y += sprd
 subdir-y += xilinx
 subdir-y += zte
+
+subdir-y += overlays


### PR DESCRIPTION
Add "subdir-y += overlays" to arch/arm64/boot/dts/Makefile to enable 'make ARCH=arm64 dtbs' to generate overlay .dtbo files